### PR TITLE
--color=auto based on STDERR instead of STDOUT

### DIFF
--- a/strace-with-colors.patch
+++ b/strace-with-colors.patch
@@ -676,7 +676,7 @@ index a35aed8eb..c1a5a5b47 100644
  
 +	// --color=auto (default)
 +	if(no_color_flag == -1)
-+		no_color_flag = !isatty(STDOUT_FILENO);
++		no_color_flag = !isatty(STDERR_FILENO);
 +
 +	// if we set NO_COLOR or use --output
 +	if((getenv("NO_COLOR")) || outfname)


### PR DESCRIPTION
`strace` outputs to STDERR, so it should check STDERR  rather than STDOUT for `--color=auto`.

I built and ran successfully with this modified patch.