### PR TITLE
Allow outputting color with `--output` with `--color=always`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ From `strace --help`
 
 + `always` will always colorize the output
 + `never` will never colorize the output
-+ `auto` will only colorize the output when standard output is connected to a terminal
++ `auto` will only colorize the output when standard output is connected to a terminal and `--output` is not used.
 
-Using `--output` or setting the `NO_COLOR` environment variable will disable the colored output.
+Setting the `NO_COLOR` environment variable will disable the colored output.
 
 ## Installation
 

--- a/strace-with-colors.patch
+++ b/strace-with-colors.patch
@@ -673,11 +673,11 @@ index 85d69485f..0c43e0d6d 100644
  	}
  
 +	// --color=auto (default)
-+	if(no_color_flag == -1)
++	if(no_color_flag == -1 && !outfname)
 +		no_color_flag = !isatty(STDOUT_FILENO);
 +
-+	// if we set NO_COLOR or use --output
-+	if((getenv("NO_COLOR")) || outfname)
++	// if we set NO_COLOR
++	if(getenv("NO_COLOR"))
 +		no_color_flag = 1;
 +
  	/*


### PR DESCRIPTION
This allows forcing color output even when outputting to a file, with `--color=always`. `-o /some/file` with the default `--color=auto` will still default to no color.

This makes it easy to separate the colorful strace output from the output of another program that is writing to stderr. It's also handy for showing strace's color output on another terminal from the command being run.